### PR TITLE
Refactor : CommentCount

### DIFF
--- a/src/main/java/com/reborn/back/board/controller/BoardController.java
+++ b/src/main/java/com/reborn/back/board/controller/BoardController.java
@@ -60,7 +60,8 @@ public class BoardController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         User user = userService.findUserByUserName(customUserDetails.getUsername());
-        Board board = boardService.findById(boardId);
+
+        Board board = boardService.findByIdWithSync(boardId);
 
         boardService.increaseViewCount(boardId, user.getUid());
 

--- a/src/main/java/com/reborn/back/board/service/BoardService.java
+++ b/src/main/java/com/reborn/back/board/service/BoardService.java
@@ -4,6 +4,7 @@ import com.reborn.back.board.converter.BoardConverter;
 import com.reborn.back.board.dto.BoardRequestDto.BoardReqDto;
 import com.reborn.back.board.repository.BoardLikeRepository;
 import com.reborn.back.board.repository.BoardRepository;
+import com.reborn.back.comment.repository.CommentRepository;
 import com.reborn.back.domain.board.Board;
 import com.reborn.back.domain.entity.BoardType;
 import com.reborn.back.domain.user.User;
@@ -31,6 +32,7 @@ public class BoardService {
 
     private final BoardRepository boardRepository;
     private final BoardLikeRepository boardLikeRepository;
+    private final CommentRepository commentRepository;
     private final AmazonS3Manager amazonS3Manager;
     private final RedisUtil redisUtil;
 
@@ -144,10 +146,6 @@ public class BoardService {
         return boardRepository.save(board);
     }
 
-    /*
-    todo
-      Redis Cache 글 삭제시 같이 삭제
-     */
     // 게시물 삭제
     @Transactional
     public void deleteBoard(Integer bId, User user) {
@@ -184,5 +182,21 @@ public class BoardService {
         Slice<Board> boardSlice = boardRepository.findByBoardLikeList_User_UidOrderByCreatedAtDesc(user.getUid(), pageRequest);
 
         return boardSlice.getContent();
+    }
+
+    // DB에 저장된 commentCount와 실제 Comment 개수를 비교(필요 시 업데이트)
+    @Transactional
+    public Board findByIdWithSync(Integer boardId) {
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new GeneralException(ErrorCode.BOARD_NOT_FOUND));
+
+        Integer actualCommentCount = commentRepository.countByBoard(board);
+
+        if (board.getCommentCount() != actualCommentCount) {
+            board.setCommentCount(actualCommentCount);
+            boardRepository.save(board);
+        }
+
+        return board;
     }
 }

--- a/src/main/java/com/reborn/back/comment/converter/CommentConverter.java
+++ b/src/main/java/com/reborn/back/comment/converter/CommentConverter.java
@@ -18,7 +18,6 @@ public class CommentConverter {
                 .user(user)
                 .board(board)
                 .contents(comment.getContents())
-                .isDeleted(false)
                 .build();
     }
 

--- a/src/main/java/com/reborn/back/comment/repository/CommentRepository.java
+++ b/src/main/java/com/reborn/back/comment/repository/CommentRepository.java
@@ -15,6 +15,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findById(Integer cId);
 
     // 삭제되지 않은 특정 게시글의 댓글을 내림차순 정렬하여 조회
-    List<Comment> findAllByBoardAndIsDeletedFalseOrderByIdDesc(Board board);
+    List<Comment> findAllByBoardOrderByIdDesc(Board board);
+
+    // 특정 게시물의 실제 댓글 개수 조회
+    Integer countByBoard(Board board);
 }
 

--- a/src/main/java/com/reborn/back/comment/service/CommentService.java
+++ b/src/main/java/com/reborn/back/comment/service/CommentService.java
@@ -31,7 +31,7 @@ public class CommentService {
         Comment comment = CommentConverter.saveComment(commentDto, board, user);
 
         commentRepository.save(comment);
-        boardRepository.incrementCommentCount(boardId);
+        boardRepository.incrementCommentCount(boardId); // 댓글 수 +1
 
         return comment.getId();
     }
@@ -45,11 +45,10 @@ public class CommentService {
             throw new GeneralException(ErrorCode.COMMENT_DELETE_NOT_ALLOWED);
         }
 
-        comment.setIsDeleted(true);
-        commentRepository.save(comment);
 
-        boardRepository.decrementCommentCount(comment.getBoard().getId());  // ✅ 댓글 수 -1
+        commentRepository.delete(comment);
 
+        boardRepository.decrementCommentCount(comment.getBoard().getId());  // 댓글 수 -1
 
         return true;
     }
@@ -57,6 +56,6 @@ public class CommentService {
     public List<Comment> findAllByBoardId(Integer boardId) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new GeneralException(ErrorCode.BOARD_NOT_FOUND));
-        return commentRepository.findAllByBoardAndIsDeletedFalseOrderByIdDesc(board);
+        return commentRepository.findAllByBoardOrderByIdDesc(board);
     }
 }

--- a/src/main/java/com/reborn/back/domain/comment/Comment.java
+++ b/src/main/java/com/reborn/back/domain/comment/Comment.java
@@ -6,10 +6,6 @@ import com.reborn.back.domain.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Table(name = "comment")
 @Getter
@@ -27,9 +23,6 @@ public class Comment extends BaseEntity {
     @Lob
     @Column(name = "cContents", columnDefinition = "longtext", nullable = false)
     private String contents;
-
-    @Column(name = "cIsDeleted", nullable = false)
-    private Boolean isDeleted;
 
     // FK: bId → Board(bId)
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 😶‍🌫️ Why I Did

- 댓글 작성 및 삭제 과정에서 생길 수 있는 문제 해결

## 😎 What I Did

- 댓글 삭제 시 DB에서도 삭제되는 방법으로 변경
- 게시물 조회 시, DB의 댓글 수와 실제 Board의 댓글 수를 비교해 동기화 하는 로직 추가

## 📸 ScreenShot

![image](https://github.com/user-attachments/assets/aadd8af8-06f7-4591-b0bd-0ce125a0f0a8)
![image](https://github.com/user-attachments/assets/f5454aff-55e8-4000-b32f-ab0eb8a5c699)
![image](https://github.com/user-attachments/assets/b20d350c-74e5-4880-85f8-ac7222538c52)

1. 실제로 댓글 삭제 및 commentCount 감소 확인 

![image](https://github.com/user-attachments/assets/4b712bdd-06c5-48a1-9b5c-ef31a57c8026)
![image](https://github.com/user-attachments/assets/a98c2347-13f2-4d0c-ba3e-4285e827287c)
![image](https://github.com/user-attachments/assets/5b2b9e34-44e8-4112-a383-6437760835c9)

2. 동기화 시키는 로직 추가(log를 추가해 동작이 되는지 확인)

## 💡 Reviewer Must Check Things

- 편하게 보셔도 됩니다 :)